### PR TITLE
[BUGFIX] execute scripts when DOM is ready

### DIFF
--- a/numbers.html
+++ b/numbers.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <title>Memorize Numbers</title>
     <link rel="stylesheet" href="style.css">
-    <script src="script.js"></script>
 </head>
 <body>
 <span class="centered" id="number"></span>
@@ -33,4 +32,5 @@
 </div>
 
 </body>
+<script src="script.js"></script>
 </html>


### PR DESCRIPTION
`document.onload` starts after all assets (like images, scripts, stylesheets) have been loaded, *NOT* when the DOM-creation has been finished. The executions starts when the DOM is not ready for manipulation.
Solution: import scripts after the DOM has been created.