### PR TITLE
[BUGFIX] generated Number no longer vanishes instantly

### DIFF
--- a/script.js
+++ b/script.js
@@ -11,7 +11,7 @@ var div = document.getElementById("number");
 function start() {
     number_of_Digits = 3;
     generateNumber();
-    window.setTimeout(vanishNumber(),10000);
+    window.setTimeout(vanishNumber,10000);
 }
 
 function generateNumber() {


### PR DESCRIPTION
`window.setTimeout` takes a functionname as the first argument
in this case the function was called